### PR TITLE
DOC Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # S<sup>3</sup>N<sup>2</sup>Bin (Semi-supervised Siamese Neural Network for metagenomic binning)
 
 
+_NOTE_: This tool is still in development. You are welcome to try it out and
+feedback is appreciated, but expect some bugs/rapid changes until it
+stabilizes.
 
-Command tool for metagenomic binning with semi-supervised deep leaning using additional information from reference genomes.
+Command tool for metagenomic binning with semi-supervised deep learning using
+information from reference genomes.
 
 ## Install
 
@@ -18,7 +22,10 @@ python setup.py install
 
 ## Generate Cannot-link contrains
 
-  You can use [CAT](https://github.com/dutilh/CAT)(or other contig annotation tools) to get the taxonomic classifications of contigs. Then you can use the script `script/concatenate.py` to generate the cannot-link file(contig_1,contig_2 ) that can be used in S<sup>3</sup>N<sup>2</sup>Bin. 
+You can use [CAT](https://github.com/dutilh/CAT) (or other contig annotation
+tools) to get taxonomic classifications of contigs. Then you can use the script
+`script/concatenate.py` to generate the cannot-link file(contig1, contig2)
+that can be used in S<sup>3</sup>N<sup>2</sup>Bin.
 
 ```bash
 python script/concatenate.py -i CAT.out -c contig.fna -s sample-name -o output
@@ -32,7 +39,7 @@ python script/concatenate.py -i CAT.out -c contig.fna -s sample-name -o output
 S3N2Bin -i contig.fna -b *.bam -c cannot-link.txt -o output 
 ```
 
-### Multiple samples binning(Must set -s parameter)
+### Multiple samples binning (Must set `-s` parameter)
 
 ```bash
 S3N2Bin -i whole_contig.fna -b *.bam -c *.txt -s C -o output
@@ -63,7 +70,7 @@ ATGCAAAA
 
 (2) Map reads to the concatenated contig file to get the bam files.
 
-(3) Generate cannot-link files for every sample. The name of the cannot-link file is <sample_name>.txt. Make sure the sample name here is same to that in step(1).
+(3) Generate cannot-link files for every sample. The name of the cannot-link file should be <sample_name>.txt. Make sure the sample name here is same to that in step 1.
 
 (4) Run S<sup>3</sup>N<sup>2</sup>Bin.
 
@@ -77,7 +84,7 @@ The output folder will contain
 
 3. Output bins.
 
-4. Some intermediate files. 
+4. Some intermediate files.
 
 For more details, read the docs.
 

--- a/s3n2bin/main.py
+++ b/s3n2bin/main.py
@@ -29,13 +29,13 @@ def parse_args(args):
                         required=True,
                         nargs='*',
                         help='Path to the input bam file.'
-                             'If using mulptile samples binning, you can input multiple files.',
+                             'If using multiple samples binning, you can input multiple files.',
                         dest='bams',
                         default=None)
     basic.add_argument('-c','--cannot-link',
                         required=True,
-                        help='Path to the input can not link file generated from other additional biological information,'
-                             'one row for each can not link constraint.'
+                        help='Path to the input cannot link file generated from other additional biological information,'
+                             'one row for each cannot link constraint.'
                              'The file format: contig_1,contig_2.',
                         dest='cannot_link',
                         default=None)
@@ -47,7 +47,7 @@ def parse_args(args):
     basic.add_argument('-s','--separator',
                         required=False,
                         type=str,
-                        help='Used when multiple samples binning to separete sample name and contig name.(None means single sample and coassemble binning)',
+                        help='Used when multiple samples binning to separate sample name and contig name. (None means single sample and coassemble binning)',
                         dest='separator',
                         default=None,
                        )
@@ -56,7 +56,7 @@ def parse_args(args):
     optional.add_argument('-p','--processes',
                         required=False,
                         type=int,
-                        help='Number of subprocess used in processing bam files()',
+                        help='Number of CPUs used',
                         dest='num_process',
                         default=0)
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(name='semi_metabin',
       long_description = long_description,
       long_description_content_type = 'text/markdown',
       classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -41,3 +45,4 @@ setup(name='semi_metabin',
             'console_scripts': ['S3N2Bin=s3n2bin.main:main'],
       }
 )
+


### PR DESCRIPTION
Fix some minor typos in the docs and add a message about how this is all very experimental so that people don't start using it while expecting it to be polished (we will want people to use it, but not yet)